### PR TITLE
[Feature] 승부예측 결과 정산 기능 구현

### DIFF
--- a/src/main/java/com/woorifisa/kboxwoori/batch/prediction/CalcPredictionStepConfig.java
+++ b/src/main/java/com/woorifisa/kboxwoori/batch/prediction/CalcPredictionStepConfig.java
@@ -1,0 +1,89 @@
+package com.woorifisa.kboxwoori.batch.prediction;
+
+import com.woorifisa.kboxwoori.batch.prediction.processor.CalcPredictionProcessor;
+import com.woorifisa.kboxwoori.batch.prediction.reader.CalcPredictionReader;
+import com.woorifisa.kboxwoori.batch.prediction.writer.PredictionNotificationWriter;
+import com.woorifisa.kboxwoori.batch.prediction.writer.SavePredictionResultWriter;
+import com.woorifisa.kboxwoori.batch.prediction.writer.UpdatePointHistoryWriter;
+import com.woorifisa.kboxwoori.batch.prediction.writer.UpdatePointWriter;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.core.Step;
+import org.springframework.batch.core.configuration.annotation.JobScope;
+import org.springframework.batch.core.configuration.annotation.StepBuilderFactory;
+import org.springframework.batch.core.configuration.annotation.StepScope;
+import org.springframework.batch.item.ItemProcessor;
+import org.springframework.batch.item.ItemReader;
+import org.springframework.batch.item.ItemWriter;
+import org.springframework.batch.item.support.CompositeItemWriter;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+import javax.sql.DataSource;
+import java.util.Arrays;
+import java.util.Map;
+
+@Slf4j
+@RequiredArgsConstructor
+@Configuration
+public class CalcPredictionStepConfig {
+
+    private final StepBuilderFactory stepBuilderFactory;
+    private final RedisTemplate<String, String> redisTemplate;
+    private final JdbcTemplate jdbcTemplate;
+    private final DataSource dataSource;
+
+    //TODO: job parameter date 추가
+    @Bean
+    @JobScope
+    public Step calcPredictionStep() {
+        return stepBuilderFactory.get("calcPredictionStep")
+                .<Map.Entry<Object, Object>, UserPrediction>chunk(100)
+                .reader(calcPredictionReader())
+                .processor(calcPredictionProcessor())
+                .writer(compositeItemWriter())
+                .build();
+    }
+
+    @Bean
+    @StepScope
+    public ItemReader<Map.Entry<Object, Object>> calcPredictionReader() {
+        return new CalcPredictionReader(redisTemplate);
+    }
+
+    @Bean
+    @StepScope
+    public ItemProcessor<Map.Entry<Object, Object>, UserPrediction> calcPredictionProcessor() {
+        return new CalcPredictionProcessor(redisTemplate, jdbcTemplate);
+    }
+
+    @Bean
+    @StepScope
+    public CompositeItemWriter<UserPrediction> compositeItemWriter() {
+        CompositeItemWriter<UserPrediction> itemWriter = new CompositeItemWriter<UserPrediction>();
+        itemWriter.setDelegates(Arrays.asList(updatePointWriter(), updatePointHistoryWriter(), savePredictionResultWriter(), predictionNotificationWriter()));
+        return itemWriter;
+    }
+
+    @StepScope
+    public ItemWriter<UserPrediction> updatePointWriter() {
+        return new UpdatePointWriter(dataSource);
+    }
+
+    @StepScope
+    public ItemWriter<UserPrediction> updatePointHistoryWriter() {
+        return new UpdatePointHistoryWriter(dataSource);
+    }
+
+    @StepScope
+    public ItemWriter<UserPrediction> savePredictionResultWriter() {
+        return new SavePredictionResultWriter(dataSource);
+    }
+
+    @StepScope
+    public ItemWriter<UserPrediction> predictionNotificationWriter() {
+        return new PredictionNotificationWriter(dataSource);
+    }
+}

--- a/src/main/java/com/woorifisa/kboxwoori/batch/prediction/PredictionJobConfig.java
+++ b/src/main/java/com/woorifisa/kboxwoori/batch/prediction/PredictionJobConfig.java
@@ -1,0 +1,24 @@
+package com.woorifisa.kboxwoori.batch.prediction;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.Step;
+import org.springframework.batch.core.configuration.annotation.JobBuilderFactory;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@RequiredArgsConstructor
+@Configuration
+public class PredictionJobConfig {
+
+    private final JobBuilderFactory jobBuilderFactory;
+    private final Step calcPredictionStep;
+
+    @Bean
+    public Job predictionJob() {
+        return jobBuilderFactory.get("predictionJob")
+                .start(calcPredictionStep)
+                .build();
+    }
+
+}

--- a/src/main/java/com/woorifisa/kboxwoori/batch/prediction/UserPrediction.java
+++ b/src/main/java/com/woorifisa/kboxwoori/batch/prediction/UserPrediction.java
@@ -1,0 +1,13 @@
+package com.woorifisa.kboxwoori.batch.prediction;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.ToString;
+
+@Getter
+@ToString
+@AllArgsConstructor
+public class UserPrediction {
+    private Long id;
+    private int extraPoints;
+}

--- a/src/main/java/com/woorifisa/kboxwoori/batch/prediction/processor/CalcPredictionProcessor.java
+++ b/src/main/java/com/woorifisa/kboxwoori/batch/prediction/processor/CalcPredictionProcessor.java
@@ -1,0 +1,71 @@
+package com.woorifisa.kboxwoori.batch.prediction.processor;
+
+import com.woorifisa.kboxwoori.batch.prediction.UserPrediction;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.item.ItemProcessor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+import javax.annotation.PostConstruct;
+import java.time.LocalDate;
+import java.util.*;
+import java.util.function.Predicate;
+
+@Slf4j
+@RequiredArgsConstructor
+public class CalcPredictionProcessor implements ItemProcessor<Map.Entry<Object, Object>, UserPrediction> {
+
+    private final RedisTemplate<String, String> redisTemplate;
+    private final JdbcTemplate jdbcTemplate;
+
+    private static final String TODAY_SCHEDULE_KEY = "crawling:todaySchedule:";
+    private static final String FIND_USER_SQL = "SELECT id FROM users WHERE user_id = ?";
+    private static final int CORRECT_ANSWER_POINTS = 3;
+    private List<String> winningTeams;
+
+    @PostConstruct
+    public void init() {
+        winningTeams = new ArrayList<>();
+        Set<String> keys = redisTemplate.keys(TODAY_SCHEDULE_KEY + LocalDate.now() + "-?");
+        if (keys != null) {
+            getWinningTeams(keys);
+            log.info("winningTeams = {}", winningTeams);
+        }
+    }
+
+    private void getWinningTeams(Set<String> keys) {
+        for (String key : keys) {
+            Map<Object, Object> match = redisTemplate.opsForHash().entries(key);
+            int team1Score = Integer.parseInt(match.get("team1Score").toString());
+            int team2Score = Integer.parseInt(match.get("team2Score").toString());
+
+            if (team1Score > team2Score) {
+                winningTeams.add(redisTemplate.opsForHash().get(key, "team1Name").toString());
+            } else if (team1Score < team2Score) {
+                winningTeams.add(redisTemplate.opsForHash().get(key, "team2Name").toString());
+            }
+        }
+    }
+
+    @Override
+    public UserPrediction process(Map.Entry<Object, Object> item) throws Exception {
+        String userId = (String) item.getKey();
+        String predictions = (String) item.getValue();
+        List<String> predictionsList = Arrays.asList(predictions.substring(1, predictions.length() - 1).split(", "));
+        log.info("userId = {}, predictionsList = {}", userId, predictionsList);
+
+        Long id = jdbcTemplate.queryForObject(FIND_USER_SQL, Long.class, userId);
+
+        int count = comparePredictionResults(predictionsList);
+
+        int extraPoints = CORRECT_ANSWER_POINTS * count;
+
+        return new UserPrediction(id, extraPoints);
+    }
+
+    private int comparePredictionResults(List<String> predictionsList) {
+        return (int) predictionsList.stream().filter(p -> winningTeams.stream()
+                .anyMatch(Predicate.isEqual(p))).count();
+    }
+}

--- a/src/main/java/com/woorifisa/kboxwoori/batch/prediction/reader/CalcPredictionReader.java
+++ b/src/main/java/com/woorifisa/kboxwoori/batch/prediction/reader/CalcPredictionReader.java
@@ -1,0 +1,36 @@
+package com.woorifisa.kboxwoori.batch.prediction.reader;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.item.ItemReader;
+import org.springframework.data.redis.core.Cursor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ScanOptions;
+
+import javax.annotation.PostConstruct;
+import java.time.LocalDate;
+import java.util.Map;
+
+@Slf4j
+@RequiredArgsConstructor
+public class CalcPredictionReader implements ItemReader<Map.Entry<Object, Object>> {
+
+    private final RedisTemplate<String, String> redisTemplate;
+
+    private static final int COUNT = 100;
+    private static final String PREDICTION_KEY = "prediction:";
+
+    private Cursor<Map.Entry<Object, Object>> cursor;
+
+    @PostConstruct
+    public void init() {
+        ScanOptions options = ScanOptions.scanOptions().count(COUNT).build();
+        this.cursor = redisTemplate.opsForHash().scan(PREDICTION_KEY + LocalDate.now(), options);
+    }
+
+    @Override
+    public Map.Entry<Object, Object> read() {
+        log.info("Item Reader read()");
+        return cursor.hasNext() ? cursor.next() : null;
+    }
+}

--- a/src/main/java/com/woorifisa/kboxwoori/batch/prediction/writer/PredictionNotificationWriter.java
+++ b/src/main/java/com/woorifisa/kboxwoori/batch/prediction/writer/PredictionNotificationWriter.java
@@ -1,0 +1,46 @@
+package com.woorifisa.kboxwoori.batch.prediction.writer;
+
+import com.woorifisa.kboxwoori.batch.prediction.UserPrediction;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.item.ItemWriter;
+import org.springframework.batch.item.database.ItemPreparedStatementSetter;
+import org.springframework.batch.item.database.JdbcBatchItemWriter;
+import org.springframework.batch.item.database.builder.JdbcBatchItemWriterBuilder;
+
+import javax.sql.DataSource;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.sql.Timestamp;
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Slf4j
+@RequiredArgsConstructor
+public class PredictionNotificationWriter implements ItemWriter<UserPrediction> {
+
+    private final DataSource dataSource;
+
+    private static final String NOTIFICATION_TYPE = "P";
+    private static final String SAVE_NOTIFICATION_SQL = "INSERT INTO notification (user_id, type, created_at, is_checked, metadata) VALUES (?, ?, ?, ?, ?)";
+
+    @Override
+    public void write(List<? extends UserPrediction> items) throws Exception {
+        JdbcBatchItemWriter<UserPrediction> writer = new JdbcBatchItemWriterBuilder<UserPrediction>()
+                .dataSource(dataSource)
+                .sql(SAVE_NOTIFICATION_SQL)
+                .itemPreparedStatementSetter(new ItemPreparedStatementSetter<UserPrediction>() {
+                    @Override
+                    public void setValues(UserPrediction item, PreparedStatement ps) throws SQLException {
+                        ps.setLong(1, item.getId());
+                        ps.setString(2, NOTIFICATION_TYPE);
+                        ps.setTimestamp(3, Timestamp.valueOf(LocalDateTime.now()));
+                        ps.setBoolean(4, false);
+                        ps.setLong(5, item.getExtraPoints());
+                    }
+                })
+                .build();
+
+        writer.write(items);
+    }
+}

--- a/src/main/java/com/woorifisa/kboxwoori/batch/prediction/writer/SavePredictionResultWriter.java
+++ b/src/main/java/com/woorifisa/kboxwoori/batch/prediction/writer/SavePredictionResultWriter.java
@@ -1,0 +1,43 @@
+package com.woorifisa.kboxwoori.batch.prediction.writer;
+
+import com.woorifisa.kboxwoori.batch.prediction.UserPrediction;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.item.ItemWriter;
+import org.springframework.batch.item.database.ItemPreparedStatementSetter;
+import org.springframework.batch.item.database.JdbcBatchItemWriter;
+import org.springframework.batch.item.database.builder.JdbcBatchItemWriterBuilder;
+
+import javax.sql.DataSource;
+import java.sql.Date;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.time.LocalDate;
+import java.util.List;
+
+@Slf4j
+@RequiredArgsConstructor
+public class SavePredictionResultWriter implements ItemWriter<UserPrediction> {
+
+    private final DataSource dataSource;
+
+    private static final String SAVE_PREDICTION_RESULT_SQL = "INSERT INTO prediction_history (user_id, is_correct, created_at) VALUES (?, ?, ?)";
+
+    @Override
+    public void write(List<? extends UserPrediction> items) throws Exception {
+        JdbcBatchItemWriter<UserPrediction> writer = new JdbcBatchItemWriterBuilder<UserPrediction>()
+                .dataSource(dataSource)
+                .sql(SAVE_PREDICTION_RESULT_SQL)
+                .itemPreparedStatementSetter(new ItemPreparedStatementSetter<UserPrediction>() {
+                    @Override
+                    public void setValues(UserPrediction item, PreparedStatement ps) throws SQLException {
+                        ps.setLong(1, item.getId());
+                        ps.setBoolean(2, item.getExtraPoints() != 0);
+                        ps.setDate(3, Date.valueOf(LocalDate.now()));
+                    }
+                })
+                .build();
+
+        writer.write(items);
+    }
+}

--- a/src/main/java/com/woorifisa/kboxwoori/batch/prediction/writer/UpdatePointHistoryWriter.java
+++ b/src/main/java/com/woorifisa/kboxwoori/batch/prediction/writer/UpdatePointHistoryWriter.java
@@ -1,0 +1,45 @@
+package com.woorifisa.kboxwoori.batch.prediction.writer;
+
+import com.woorifisa.kboxwoori.batch.prediction.UserPrediction;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.item.ItemWriter;
+import org.springframework.batch.item.database.ItemPreparedStatementSetter;
+import org.springframework.batch.item.database.JdbcBatchItemWriter;
+import org.springframework.batch.item.database.builder.JdbcBatchItemWriterBuilder;
+
+import javax.sql.DataSource;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.sql.Timestamp;
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Slf4j
+@RequiredArgsConstructor
+public class UpdatePointHistoryWriter implements ItemWriter<UserPrediction> {
+
+    private final DataSource dataSource;
+
+    private static final String UPDATE_POINT_HISTORY_SQL = "INSERT INTO point_history (user_id, status_code, point, created_at) VALUES (?, ?, ?, ?)";
+    private static final String POINT_HISTORY_STATUS = "SAVE";
+
+    @Override
+    public void write(List<? extends UserPrediction> items) throws Exception {
+        JdbcBatchItemWriter<UserPrediction> writer = new JdbcBatchItemWriterBuilder<UserPrediction>()
+                .dataSource(dataSource)
+                .sql(UPDATE_POINT_HISTORY_SQL)
+                .itemPreparedStatementSetter(new ItemPreparedStatementSetter<UserPrediction>() {
+                    @Override
+                    public void setValues(UserPrediction item, PreparedStatement ps) throws SQLException {
+                        ps.setLong(1, item.getId());
+                        ps.setString(2, POINT_HISTORY_STATUS);
+                        ps.setInt(3, item.getExtraPoints());
+                        ps.setTimestamp(4, Timestamp.valueOf(LocalDateTime.now()));
+                    }
+                })
+                .build();
+
+        writer.write(items);
+    }
+}

--- a/src/main/java/com/woorifisa/kboxwoori/batch/prediction/writer/UpdatePointWriter.java
+++ b/src/main/java/com/woorifisa/kboxwoori/batch/prediction/writer/UpdatePointWriter.java
@@ -1,0 +1,40 @@
+package com.woorifisa.kboxwoori.batch.prediction.writer;
+
+import com.woorifisa.kboxwoori.batch.prediction.UserPrediction;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.item.ItemWriter;
+import org.springframework.batch.item.database.ItemPreparedStatementSetter;
+import org.springframework.batch.item.database.JdbcBatchItemWriter;
+import org.springframework.batch.item.database.builder.JdbcBatchItemWriterBuilder;
+
+import javax.sql.DataSource;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.util.List;
+
+@Slf4j
+@RequiredArgsConstructor
+public class UpdatePointWriter implements ItemWriter<UserPrediction> {
+
+    private final DataSource dataSource;
+
+    private static final String UPDATE_POINT_SQL = "UPDATE users SET point = point + ? WHERE id = ?";
+
+    @Override
+    public void write(List<? extends UserPrediction> items) throws Exception {
+        JdbcBatchItemWriter<UserPrediction> writer = new JdbcBatchItemWriterBuilder<UserPrediction>()
+                .dataSource(dataSource)
+                .sql(UPDATE_POINT_SQL)
+                .itemPreparedStatementSetter(new ItemPreparedStatementSetter<UserPrediction>() {
+                    @Override
+                    public void setValues(UserPrediction item, PreparedStatement ps) throws SQLException {
+                        ps.setInt(1, item.getExtraPoints());
+                        ps.setLong(2, item.getId());
+                    }
+                })
+                .build();
+
+        writer.write(items);
+    }
+}


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면
  close #Issue_number를 적어주세요 -->
- close #3 
## ✨ 작업 내용
<!-- 과제에 대한 설명을 적어주세요 -->
- redis에서 유저의 예측 값을 읽어오는 itemReader 구현
- 경기 결과와 비교 후 포인트와 userId를 반환하는 itemProcessor 구현
- 포인트 정산 및 포인트 내역, 알림, 승부예측 결과 갱신을 위한 itemWriter 구현
- Step 및 Job 생성

## 📚 Reference
<!-- 참고할 사항이 있다면 적어주세요 -->
- [CompositeItemWriter를 사용하여 하나의 Step에 여러개의 ItemWriter 등록하기](https://velog.io/@gongmeda/CompositeItemWriter%EB%A5%BC-%EC%82%AC%EC%9A%A9%ED%95%98%EC%97%AC-%ED%95%98%EB%82%98%EC%9D%98-Step%EC%97%90-%EC%97%AC%EB%9F%AC%EA%B0%9C%EC%9D%98-ItemWriter-%EB%93%B1%EB%A1%9D%ED%95%98%EA%B8%B0)
