### PR TITLE
[Feature] 관리자용 통계 데이터 저장 기능 구현

### DIFF
--- a/src/main/java/com/woorifisa/kboxwoori/batch/admin/AdminJobConfig.java
+++ b/src/main/java/com/woorifisa/kboxwoori/batch/admin/AdminJobConfig.java
@@ -1,0 +1,27 @@
+package com.woorifisa.kboxwoori.batch.admin;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.Step;
+import org.springframework.batch.core.configuration.annotation.JobBuilderFactory;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@RequiredArgsConstructor
+@Configuration
+public class AdminJobConfig {
+
+    private final JobBuilderFactory jobBuilderFactory;
+    private final Step saveMemberCountStep;
+    private final Step savePredictionParticipantCountStep;
+    private final Step saveQuizParticipantCountStep;
+
+    @Bean
+    public Job adminJob() {
+        return jobBuilderFactory.get("adminJob")
+                .start(saveMemberCountStep)
+                .next(savePredictionParticipantCountStep)
+                .next(saveQuizParticipantCountStep)
+                .build();
+    }
+}

--- a/src/main/java/com/woorifisa/kboxwoori/batch/admin/SaveMemberCountStepConfig.java
+++ b/src/main/java/com/woorifisa/kboxwoori/batch/admin/SaveMemberCountStepConfig.java
@@ -1,0 +1,49 @@
+package com.woorifisa.kboxwoori.batch.admin;
+
+import com.woorifisa.kboxwoori.batch.admin.reader.SaveMemberCountReader;
+import com.woorifisa.kboxwoori.batch.admin.writer.SaveMemberCountWriter;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.core.Step;
+import org.springframework.batch.core.configuration.annotation.JobScope;
+import org.springframework.batch.core.configuration.annotation.StepBuilderFactory;
+import org.springframework.batch.core.configuration.annotation.StepScope;
+import org.springframework.batch.item.ItemReader;
+import org.springframework.batch.item.ItemWriter;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+import javax.sql.DataSource;
+
+@Slf4j
+@RequiredArgsConstructor
+@Configuration
+public class SaveMemberCountStepConfig {
+
+    private final StepBuilderFactory stepBuilderFactory;
+    private final JdbcTemplate jdbcTemplate;
+    private final DataSource dataSource;
+
+    @Bean
+    @JobScope
+    public Step saveMemberCountStep() {
+        return stepBuilderFactory.get("saveMemberCountStep")
+                .<Integer, Integer>chunk(1)
+                .reader(saveMemberCountReader())
+                .writer(saveMemberCountWriter())
+                .build();
+    }
+
+    @Bean
+    @StepScope
+    public ItemReader<Integer> saveMemberCountReader() {
+        return new SaveMemberCountReader(jdbcTemplate);
+    }
+
+    @Bean
+    @StepScope
+    public ItemWriter<Integer> saveMemberCountWriter() {
+        return new SaveMemberCountWriter(dataSource);
+    }
+}

--- a/src/main/java/com/woorifisa/kboxwoori/batch/admin/SavePredictionParticipantCountStepConfig.java
+++ b/src/main/java/com/woorifisa/kboxwoori/batch/admin/SavePredictionParticipantCountStepConfig.java
@@ -1,0 +1,49 @@
+package com.woorifisa.kboxwoori.batch.admin;
+
+import com.woorifisa.kboxwoori.batch.admin.reader.SavePredictionParticipantCountReader;
+import com.woorifisa.kboxwoori.batch.admin.writer.SavePredictionParticipantCountWriter;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.core.Step;
+import org.springframework.batch.core.configuration.annotation.JobScope;
+import org.springframework.batch.core.configuration.annotation.StepBuilderFactory;
+import org.springframework.batch.core.configuration.annotation.StepScope;
+import org.springframework.batch.item.ItemReader;
+import org.springframework.batch.item.ItemWriter;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.core.RedisTemplate;
+
+import javax.sql.DataSource;
+
+@Slf4j
+@RequiredArgsConstructor
+@Configuration
+public class SavePredictionParticipantCountStepConfig {
+
+    private final StepBuilderFactory stepBuilderFactory;
+    private final RedisTemplate<String, String> redisTemplate;
+    private final DataSource dataSource;
+
+    @Bean
+    @JobScope
+    public Step savePredictionParticipantCountStep() {
+        return stepBuilderFactory.get("savePredictionParticipantCountStep")
+                .<Long, Long>chunk(1)
+                .reader(savePredictionParticipantCountReader())
+                .writer(savePredictionParticipantCountWriter())
+                .build();
+    }
+
+    @Bean
+    @StepScope
+    public ItemReader<Long> savePredictionParticipantCountReader() {
+        return new SavePredictionParticipantCountReader(redisTemplate);
+    }
+
+    @Bean
+    @StepScope
+    public ItemWriter<Long> savePredictionParticipantCountWriter() {
+        return new SavePredictionParticipantCountWriter(dataSource);
+    }
+}

--- a/src/main/java/com/woorifisa/kboxwoori/batch/admin/SaveQuizParticipantCountStepConfig.java
+++ b/src/main/java/com/woorifisa/kboxwoori/batch/admin/SaveQuizParticipantCountStepConfig.java
@@ -1,0 +1,49 @@
+package com.woorifisa.kboxwoori.batch.admin;
+
+import com.woorifisa.kboxwoori.batch.admin.reader.SaveQuizParticipantCountReader;
+import com.woorifisa.kboxwoori.batch.admin.writer.SaveQuizParticipantCountWriter;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.core.Step;
+import org.springframework.batch.core.configuration.annotation.JobScope;
+import org.springframework.batch.core.configuration.annotation.StepBuilderFactory;
+import org.springframework.batch.core.configuration.annotation.StepScope;
+import org.springframework.batch.item.ItemReader;
+import org.springframework.batch.item.ItemWriter;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.core.RedisTemplate;
+
+import javax.sql.DataSource;
+
+@Slf4j
+@RequiredArgsConstructor
+@Configuration
+public class SaveQuizParticipantCountStepConfig {
+
+    private final StepBuilderFactory stepBuilderFactory;
+    private final RedisTemplate<String, String> redisTemplate;
+    private final DataSource dataSource;
+
+    @Bean
+    @JobScope
+    public Step saveQuizParticipantCountStep() {
+        return stepBuilderFactory.get("saveQuizParticipantCountStep")
+                .<Long, Long>chunk(1)
+                .reader(saveQuizParticipantCountReader())
+                .writer(saveQuizParticipantCountWriter())
+                .build();
+    }
+
+    @Bean
+    @StepScope
+    public ItemReader<Long> saveQuizParticipantCountReader() {
+        return new SaveQuizParticipantCountReader(redisTemplate);
+    }
+
+    @Bean
+    @StepScope
+    public ItemWriter<Long> saveQuizParticipantCountWriter() {
+        return new SaveQuizParticipantCountWriter(dataSource);
+    }
+}

--- a/src/main/java/com/woorifisa/kboxwoori/batch/admin/reader/SaveMemberCountReader.java
+++ b/src/main/java/com/woorifisa/kboxwoori/batch/admin/reader/SaveMemberCountReader.java
@@ -1,0 +1,27 @@
+package com.woorifisa.kboxwoori.batch.admin.reader;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.item.ItemReader;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+@Slf4j
+@RequiredArgsConstructor
+public class SaveMemberCountReader implements ItemReader<Integer> {
+
+    private final JdbcTemplate jdbcTemplate;
+
+    private static final String MEMBER_COUNT_SQL = "SELECT count(*) FROM users";
+
+    private boolean isRead = false;
+
+    @Override
+    public Integer read() {
+        if (!isRead) {
+            isRead = true;
+            return jdbcTemplate.queryForObject(MEMBER_COUNT_SQL, Integer.class);
+        }
+
+        return null;
+    }
+}

--- a/src/main/java/com/woorifisa/kboxwoori/batch/admin/reader/SavePredictionParticipantCountReader.java
+++ b/src/main/java/com/woorifisa/kboxwoori/batch/admin/reader/SavePredictionParticipantCountReader.java
@@ -1,0 +1,29 @@
+package com.woorifisa.kboxwoori.batch.admin.reader;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.item.ItemReader;
+import org.springframework.data.redis.core.RedisTemplate;
+
+import java.time.LocalDate;
+
+@Slf4j
+@RequiredArgsConstructor
+public class SavePredictionParticipantCountReader implements ItemReader<Long> {
+
+    private final RedisTemplate<String, String> redisTemplate;
+
+    private static final String PREDICTION_KEY = "prediction:";
+
+    private boolean isRead = false;
+
+    @Override
+    public Long read() {
+        if (!isRead) {
+            isRead = true;
+            return redisTemplate.opsForHash().size(PREDICTION_KEY + LocalDate.now());
+        }
+
+        return null;
+    }
+}

--- a/src/main/java/com/woorifisa/kboxwoori/batch/admin/reader/SaveQuizParticipantCountReader.java
+++ b/src/main/java/com/woorifisa/kboxwoori/batch/admin/reader/SaveQuizParticipantCountReader.java
@@ -1,0 +1,29 @@
+package com.woorifisa.kboxwoori.batch.admin.reader;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.item.ItemReader;
+import org.springframework.data.redis.core.RedisTemplate;
+
+import java.time.LocalDate;
+
+@Slf4j
+@RequiredArgsConstructor
+public class SaveQuizParticipantCountReader implements ItemReader<Long> {
+
+    private final RedisTemplate<String, String> redisTemplate;
+
+    private static final String QUIZ_KEY = "quiz:participant:";
+
+    private boolean isRead = false;
+
+    @Override
+    public Long read() {
+        if (!isRead) {
+            isRead = true;
+            return redisTemplate.opsForSet().size(QUIZ_KEY + LocalDate.now());
+        }
+
+        return null;
+    }
+}

--- a/src/main/java/com/woorifisa/kboxwoori/batch/admin/writer/SaveMemberCountWriter.java
+++ b/src/main/java/com/woorifisa/kboxwoori/batch/admin/writer/SaveMemberCountWriter.java
@@ -1,0 +1,41 @@
+package com.woorifisa.kboxwoori.batch.admin.writer;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.item.ItemWriter;
+import org.springframework.batch.item.database.ItemPreparedStatementSetter;
+import org.springframework.batch.item.database.JdbcBatchItemWriter;
+import org.springframework.batch.item.database.builder.JdbcBatchItemWriterBuilder;
+
+import javax.sql.DataSource;
+import java.sql.Date;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.time.LocalDate;
+import java.util.List;
+
+@Slf4j
+@RequiredArgsConstructor
+public class SaveMemberCountWriter implements ItemWriter<Integer> {
+
+    private final DataSource dataSource;
+
+    private static final String SAVE_MEMBER_COUNT_SQL = "INSERT INTO user_statistics (total_users, created_at) VALUES (?, ?)";
+
+    @Override
+    public void write(List<? extends Integer> items) throws Exception {
+        JdbcBatchItemWriter<Integer> writer = new JdbcBatchItemWriterBuilder<Integer>()
+                .dataSource(dataSource)
+                .sql(SAVE_MEMBER_COUNT_SQL)
+                .itemPreparedStatementSetter(new ItemPreparedStatementSetter<Integer>() {
+                    @Override
+                    public void setValues(Integer item, PreparedStatement ps) throws SQLException {
+                        ps.setInt(1, item);
+                        ps.setDate(2, Date.valueOf(LocalDate.now()));
+                    }
+                })
+                .build();
+
+        writer.write(items);
+    }
+}

--- a/src/main/java/com/woorifisa/kboxwoori/batch/admin/writer/SavePredictionParticipantCountWriter.java
+++ b/src/main/java/com/woorifisa/kboxwoori/batch/admin/writer/SavePredictionParticipantCountWriter.java
@@ -1,0 +1,41 @@
+package com.woorifisa.kboxwoori.batch.admin.writer;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.item.ItemWriter;
+import org.springframework.batch.item.database.ItemPreparedStatementSetter;
+import org.springframework.batch.item.database.JdbcBatchItemWriter;
+import org.springframework.batch.item.database.builder.JdbcBatchItemWriterBuilder;
+
+import javax.sql.DataSource;
+import java.sql.Date;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.time.LocalDate;
+import java.util.List;
+
+@Slf4j
+@RequiredArgsConstructor
+public class SavePredictionParticipantCountWriter implements ItemWriter<Long> {
+
+    private final DataSource dataSource;
+
+    private static final String SAVE_PREDICTION_PARTICIPANT_COUNT_SQL = "UPDATE user_statistics SET prediction_participants = ? WHERE created_at = ?";
+
+    @Override
+    public void write(List<? extends Long> items) throws Exception {
+        JdbcBatchItemWriter<Long> writer = new JdbcBatchItemWriterBuilder<Long>()
+                .dataSource(dataSource)
+                .sql(SAVE_PREDICTION_PARTICIPANT_COUNT_SQL)
+                .itemPreparedStatementSetter(new ItemPreparedStatementSetter<Long>() {
+                    @Override
+                    public void setValues(Long item, PreparedStatement ps) throws SQLException {
+                        ps.setInt(1, item.intValue());
+                        ps.setDate(2, Date.valueOf(LocalDate.now()));
+                    }
+                })
+                .build();
+
+        writer.write(items);
+    }
+}

--- a/src/main/java/com/woorifisa/kboxwoori/batch/admin/writer/SaveQuizParticipantCountWriter.java
+++ b/src/main/java/com/woorifisa/kboxwoori/batch/admin/writer/SaveQuizParticipantCountWriter.java
@@ -1,0 +1,41 @@
+package com.woorifisa.kboxwoori.batch.admin.writer;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.item.ItemWriter;
+import org.springframework.batch.item.database.ItemPreparedStatementSetter;
+import org.springframework.batch.item.database.JdbcBatchItemWriter;
+import org.springframework.batch.item.database.builder.JdbcBatchItemWriterBuilder;
+
+import javax.sql.DataSource;
+import java.sql.Date;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.time.LocalDate;
+import java.util.List;
+
+@Slf4j
+@RequiredArgsConstructor
+public class SaveQuizParticipantCountWriter implements ItemWriter<Long> {
+
+    private final DataSource dataSource;
+
+    private static final String SAVE_QUIZ_PARTICIPANT_COUNT_SQL = "UPDATE user_statistics SET quiz_participants = ? WHERE created_at = ?";
+
+    @Override
+    public void write(List<? extends Long> items) throws Exception {
+        JdbcBatchItemWriter<Long> writer = new JdbcBatchItemWriterBuilder<Long>()
+                .dataSource(dataSource)
+                .sql(SAVE_QUIZ_PARTICIPANT_COUNT_SQL)
+                .itemPreparedStatementSetter(new ItemPreparedStatementSetter<Long>() {
+                    @Override
+                    public void setValues(Long item, PreparedStatement ps) throws SQLException {
+                        ps.setInt(1, item.intValue());
+                        ps.setDate(2, Date.valueOf(LocalDate.now()));
+                    }
+                })
+                .build();
+
+        writer.write(items);
+    }
+}

--- a/src/test/java/com/woorifisa/kboxwoori/batch/admin/AdminJobConfigTest.java
+++ b/src/test/java/com/woorifisa/kboxwoori/batch/admin/AdminJobConfigTest.java
@@ -1,0 +1,25 @@
+package com.woorifisa.kboxwoori.batch.admin;
+
+import com.woorifisa.kboxwoori.global.config.BatchConfig;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.batch.core.JobExecution;
+import org.springframework.batch.test.JobLauncherTestUtils;
+import org.springframework.batch.test.context.SpringBatchTest;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBatchTest
+@SpringBootTest(classes = {AdminJobConfig.class, SaveMemberCountStepConfig.class,
+        SavePredictionParticipantCountStepConfig.class, SaveQuizParticipantCountStepConfig.class, BatchConfig.class})
+class AdminJobConfigTest {
+
+    @Autowired
+    private JobLauncherTestUtils jobLauncherTestUtils;
+
+    @Test
+    void 통계_결과_저장_테스트() throws Exception {
+        JobExecution jobExecution = jobLauncherTestUtils.launchJob();
+        Assertions.assertEquals("COMPLETED", jobExecution.getStatus().toString());
+    }
+}


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면
  close #Issue_number를 적어주세요 -->
- close #8 
## ✨ 작업 내용
<!-- 과제에 대한 설명을 적어주세요 -->
- db에서 총 회원 수를 읽어온 후 통계 테이블에 저장하는 itemReader, itemWriter 구현
- redis에서 퀴즈 참여자 수를 읽어온 후 통계 테이블에 저장하는 itemReader, itemWriter 구현
- redis에서 승부예측 참여자 수를 읽어온 후 통계 테이블에 저장하는 itemReader, itemWriter 구현
- Step 및 Job 생성
